### PR TITLE
Add requests to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jinja2
+requests


### PR DESCRIPTION
The requests module is not a built-in module in python (currently). Since it is being used in fetch-mirrors.py, I am adding it to the requirements.txt.